### PR TITLE
Handle wrapped lines (etc.) in debian/control files

### DIFF
--- a/pylib/verseek.py
+++ b/pylib/verseek.py
@@ -208,7 +208,7 @@ class GitSingle(Git):
                      if not line.startswith(" "))
             return dict([ re.split("\s*:\s*", line, 1)
                           for line in lines
-                          if line ])
+                          if line or ':' in line])
 
         control = parse_control(self.path_control)
 

--- a/pylib/verseek.py
+++ b/pylib/verseek.py
@@ -208,7 +208,7 @@ class GitSingle(Git):
                      if not line.startswith(" "))
             return dict([ re.split("\s*:\s*", line, 1)
                           for line in lines
-                          if line or ':' in line])
+                          if line and ':' in line])
 
         control = parse_control(self.path_control)
 


### PR DESCRIPTION
Now handles non-setting constructs and wrapped lines within debian/control
files. However this does NOT make verseek truly parse debian/control files
properly.

What is does do is recreates the functionality observed previously and should
do so without regressions.